### PR TITLE
Adding missing namespace in order to fix issue #8

### DIFF
--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -21,7 +21,7 @@ module Dummy
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     # config.active_record.raise_in_transactional_callbacks = true
-    config.active_record.sqlite3.represent_boolean_as_integer = true
+    # config.active_record.sqlite3.represent_boolean_as_integer = true
   end
 end
 

--- a/test/lib/generators/acl_manager/acl_manager_generator_test.rb
+++ b/test/lib/generators/acl_manager/acl_manager_generator_test.rb
@@ -3,7 +3,7 @@ require 'generators/acl_manager/acl_manager_generator'
 
 module AclManager
   class AclManagerGeneratorTest < Rails::Generators::TestCase
-    tests AclManagerGenerator
+    tests Generators::AclManagerGenerator
     destination Rails.root.join('tmp/generators')
     setup :prepare_destination
 


### PR DESCRIPTION
Class namespace was not being found on tests  load.

So, this PR does the following:
- adds the namespace
- comments default option back since sqlite is crashing on` schema:load/db:migrate`